### PR TITLE
feat: drag only by the checkbox

### DIFF
--- a/app/components/Tasks.js
+++ b/app/components/Tasks.js
@@ -31,7 +31,7 @@ export default class Tasks extends React.Component {
   }
 
   initiateSorting() {
-    if(TasksManager.get().isMobile() || this.didInitiateSorting) {
+    if(this.didInitiateSorting) {
       return;
     }
     this.didInitiateSorting = true;
@@ -39,6 +39,7 @@ export default class Tasks extends React.Component {
     let properties = {
       draggable: '.task',
       dragClass: 'task-dragging',
+      handle: '.checkbox-container',
       onEnd: this.taskCompletedDragging
     };
 


### PR DESCRIPTION
Make sure only the checkbox is draggable so that we don't end up dragging an item by mistake in mobile instead of scrolling.

## Demo on iOS
![simple_task](https://user-images.githubusercontent.com/10207818/58762324-ed7b5a80-8546-11e9-825c-355845a6f358.gif)

Relates to: standardnotes/bounties#26